### PR TITLE
Complete i18n integration and add multilanguage manifest support

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -15,9 +15,10 @@ const image = (fileName: string) => {
 
 export const manifest: ManifestV3Export = {
   manifest_version: 3,
-  name: debug ? `DEV: ${ pkg.displayName }` : pkg.displayName,
+  name: debug ? `DEV: __MSG_extensionName__` : '__MSG_extensionName__',
+  default_locale: 'en',
   version: pkg.version,
-  description: pkg.description,
+  description: '__MSG_extensionDescription__',
   key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuoZ6iyeKFISXJhEau79T' +
     'Qd/aBiTsPO6RTt6ZAy2lm1px8pDK7PZKBNA5B8CrSa67OJyZvm8HDTVGc4xxXQ41' +
     'chG0e8ONxYi3k3QRio4u1m3H3S/5xJZtvgEgSbqOLQutdOrYLW9R3ile+AhIQZhR' +
@@ -32,7 +33,7 @@ export const manifest: ManifestV3Export = {
   action: {
     default_popup: 'src/popup/index.html',
     default_icon: image('icon-34.png'),
-    default_title: pkg.displayName,
+    default_title: '__MSG_extensionTitle__',
   },
   icons: {
     128: image('icon-128.png'),

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1,0 +1,14 @@
+{
+  "extensionName": {
+    "message": "Cookies Pack",
+    "description": "The name of the extension"
+  },
+  "extensionDescription": {
+    "message": "Flexible extensions to control your cookies",
+    "description": "The description of the extension shown in the browser store"
+  },
+  "extensionTitle": {
+    "message": "Cookies Pack",
+    "description": "The default title shown in the browser toolbar"
+  }
+}

--- a/src/core/Cookies.tsx
+++ b/src/core/Cookies.tsx
@@ -85,15 +85,15 @@ const Cookies = () => {
 
   const saveToCookieFile = useCallback(async (data: string) => {
     await saveFile(data, {
-      suggestedName: 'demo.cookies',
+      suggestedName: t('export.filename'),
       types: [
         {
-          description: 'JetBrains IDE cookies',
+          description: t('export.description'),
           accept: { 'text/plain': ['.cookies'] },
         },
       ],
     });
-  }, [saveFile]);
+  }, [saveFile, t]);
 
   const [customPath, setCustomPath] = useState(false);
   const [path, setPath] = useState('/');
@@ -137,9 +137,9 @@ const Cookies = () => {
                 value={newCookies}
                 res
                 onInput={(event) => setNewCookies(value(event))}
-                placeholder="Update cookies with a cookie header, e.g. foo=bar; bat=baz; oof=rab"/>
+                placeholder={t('input.placeholder')}/>
       <div className="flex flex-row gap-2 w-full">
-        <Input placeholder="Cookies path"
+        <Input placeholder={t('input.path_placeholder')}
                className="flex-1"
                disabled={!customPath}
                value={customPath ? path : ''}
@@ -149,7 +149,7 @@ const Cookies = () => {
             <Switch.Thumb/>
           </Switch.Control>
           <Switch.Content>
-            <Label className="text-sm">Custom path</Label>
+            <Label className="text-sm">{t('input.path_label')}</Label>
           </Switch.Content>
         </Switch>
       </div>
@@ -160,7 +160,7 @@ const Cookies = () => {
           </Switch.Control>
           <Switch.Content>
             <Label className="text-sm">
-              {t('clear_existing_cookies_first')}
+              {t('clear_first.label')}
             </Label>
           </Switch.Content>
         </Switch>

--- a/src/core/CookiesTable.tsx
+++ b/src/core/CookiesTable.tsx
@@ -46,10 +46,10 @@ export const CookiesTable: FC<CookiesTableProps> = ({ cookies, copyToClipboard, 
               </Table.Column>
               <Table.Column id="actions" minWidth={240}>
                 <ButtonGroup variant="tertiary" style={{ margin: '-6px' }}>
-                  <Button isIconOnly aria-label="Copy" size="sm" onPress={exportAll}>
+                  <Button isIconOnly aria-label={t('export_all_cookies')} size="sm" onPress={exportAll}>
                     <Icon icon="heroicons-solid:download"/>
                   </Button>
-                  <Button isIconOnly aria-label="Cut" size="sm" onPress={copyAll}>
+                  <Button isIconOnly aria-label={t('copy_all_cookies')} size="sm" onPress={copyAll}>
                     <ButtonGroup.Separator/>
                     <Icon icon="heroicons-solid:clipboard-copy"/>
                   </Button>
@@ -61,7 +61,7 @@ export const CookiesTable: FC<CookiesTableProps> = ({ cookies, copyToClipboard, 
                 className="flex h-full w-full flex-col items-center justify-center min-h-60 gap-4 text-center">
                 <Icon className="size-10 text-muted" icon="ci:cookie"/>
                 <span className="text-sm text-muted">
-                             No cookies found
+                             {t('no_cookies')}
                            </span>
               </EmptyState>
             )}>

--- a/src/core/CookiesTableCell.tsx
+++ b/src/core/CookiesTableCell.tsx
@@ -22,7 +22,7 @@ const spanStyles = {
 
 const CookiesTableCell: FC<CookiesTableCellProps> = ({ value }) => {
   const { clipboard } = useContext(PageContext);
-  const { t } = useTranslation(['cookies_table', 'cell']);
+  const { t } = useTranslation(['cookies_table']);
   const [copied, setCopied] = useTimedValue(false, 1500);
 
   const onClickInternal = useCallback(() => {

--- a/src/core/translations/en.json
+++ b/src/core/translations/en.json
@@ -1,21 +1,36 @@
 {
   "translation": {
+    "not_supported": "This page is not supported",
     "add_cookies": "Add Cookies",
     "replace_cookies": "Replace Cookies",
-    "clear_existing_cookies_first": "Clear existing cookies first",
-    "use_custom_path": "Use custom path by default",
-    "not_supported": "This page is not supported",
     "settings": {
       "title": "Default Settings",
       "open": "Open settings",
       "close": "Close settings"
+    },
+    "clear_first": {
+      "label": "Clear existing cookies first",
+      "description": "When enabled, all cookies for the current site are removed before the new ones are applied."
+    },
+    "custom_path": {
+      "label": "Use custom path by default",
+      "description": "When enabled, the path from the current page URL is pre-filled instead of using /."
+    },
+    "input": {
+      "placeholder": "Update cookies with a cookie header, e.g. foo=bar; bat=baz; oof=rab",
+      "path_placeholder": "Cookies path",
+      "path_label": "Custom path"
+    },
+    "export": {
+      "filename": "demo.cookies",
+      "description": "JetBrains IDE cookies"
     }
   },
   "cookies_table": {
-    "no_cookies": "No cookies.",
+    "no_cookies": "No cookies found",
     "delete_cookie": "Delete cookie",
-    "copy_all_cookies": "Copy all cookies.",
-    "export_all_cookies": "Export all cookies.",
+    "copy_all_cookies": "Copy all cookies",
+    "export_all_cookies": "Export all cookies",
     "aria_label": "Current site cookies",
     "columns": {
       "name": "Name",

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -1,8 +1,10 @@
 import { useClearExistingCookiesFirst, useCustomPath } from '@shared/hooks';
 import { Description, Label, Switch } from '@heroui/react';
 import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
 
 const Options: FC = () => {
+  const { t } = useTranslation();
   const [clearFirst, setClearFirst] = useClearExistingCookiesFirst();
   const [customPath, setCustomPath] = useCustomPath();
 
@@ -15,9 +17,9 @@ const Options: FC = () => {
               <Switch.Thumb/>
             </Switch.Control>
             <Switch.Content>
-              <Label className="text-sm">Clear existing cookies first</Label>
+              <Label className="text-sm">{t('clear_first.label')}</Label>
               <Description className="text-xs">
-                When enabled, all cookies for the current site are removed before the new ones are applied.
+                {t('clear_first.description')}
               </Description>
             </Switch.Content>
           </Switch>
@@ -26,10 +28,9 @@ const Options: FC = () => {
               <Switch.Thumb/>
             </Switch.Control>
             <Switch.Content>
-              <Label className="text-sm">Use custom path by default</Label>
+              <Label className="text-sm">{t('custom_path.label')}</Label>
               <Description className="text-xs">
-                When enabled, the path from the current page URL is pre-filled instead of using&nbsp;
-                <code>/</code>.
+                {t('custom_path.description')}
               </Description>
             </Switch.Content>
           </Switch>

--- a/src/options/index.tsx
+++ b/src/options/index.tsx
@@ -1,7 +1,20 @@
+import { translations } from '@core/translations';
 import Options from '@src/options/Options';
+import i18n from 'i18next';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+import { initReactI18next } from 'react-i18next';
 import '../styles.css';
+
+await i18n.use(initReactI18next)
+  .init({
+    resources: translations,
+    lng: 'en',
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false,
+    },
+  });
 
 createRoot(document.body).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary

- **Restructure `en.json`**: group keys under `clear_first`, `custom_path`, `input`, and `export` namespaces; add all previously hardcoded strings
- **Extract hardcoded UI strings** in `Cookies.tsx`, `CookiesTable.tsx`, and `Options.tsx` to translation keys
- **Fix namespace bug** in `CookiesTableCell` — phantom `'cell'` namespace removed; `cell.copied` resolves correctly under `cookies_table`
- **Initialize i18next in options page** (`options/index.tsx` was missing setup, leaving the options UI untranslated)
- **Add `public/_locales/en/messages.json`** for Chrome's native i18n API (manifest strings)
- **Update `manifest.ts`** to use `__MSG_extensionName__`, `__MSG_extensionDescription__`, `__MSG_extensionTitle__` with `default_locale: 'en'` — adding a new language now only requires a new `_locales/{lang}/messages.json` file

## Test plan

- [ ] Build succeeds (`yarn build`)
- [ ] Popup displays all text correctly (cookies table, buttons, empty state, textarea placeholder)
- [ ] Options page displays labels and descriptions (was entirely untranslated before)
- [ ] Copy/export button aria-labels are correct
- [ ] `dist/_locales/en/messages.json` present in build output
- [ ] `dist/manifest.json` contains `__MSG_` keys and `default_locale: "en"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)